### PR TITLE
Fixes bug #901

### DIFF
--- a/pyrcc/rcc.cpp
+++ b/pyrcc/rcc.cpp
@@ -58,7 +58,7 @@ static bool qt_rcc_write_number(FILE *out, quint32 number, int width)
     while (dividend >= 1) {
         const quint8 tmp = number / dividend;
 
-        if (tmp >= 32 && tmp <= 127) {
+        if (tmp >= 32 && tmp < 127 && tmp != '"' && tmp != '\\') {
             /* Optimization for printable characters */
             fprintf(out, "%c", tmp);
         } else {


### PR DESCRIPTION
The space optimization trick printed a sequence of invalid characters,
namely '\x', which are used to introduce a encoded character.
