### PR TITLE
pysideuic: fix passing of file-like object to 'compileUi' for Python 3.x

### DIFF
--- a/pysideuic/Compiler/compiler.py
+++ b/pysideuic/Compiler/compiler.py
@@ -88,7 +88,7 @@ class UICompiler(UIParser):
 
     def compileUi(self, input_stream, output_stream, from_imports):
         createCodeIndenter(output_stream)
-        w = self.parse(input_stream)
+        w = self.parse(input_stream.name)
 
         indenter = getIndenter()
         indenter.write("")

--- a/pysideuic/__init__.py.in
+++ b/pysideuic/__init__.py.in
@@ -133,6 +133,7 @@ def compileUi(uifile, pyfile, execute=False, indent=4, from_imports=False):
         uifname = uifile.name
     except AttributeError:
         uifname = uifile
+        uifile = open(uifile, 'r')
 
     indenter.indentwidth = indent
 


### PR DESCRIPTION
Should also fix the 'compileUiDir' function in the package for Python 3.
