### PR TITLE
Add support (and remove crash) for Theme icons from QtDesigner

### DIFF
--- a/pysideuic/Compiler/qtproxies.py
+++ b/pysideuic/Compiler/qtproxies.py
@@ -220,7 +220,10 @@ class QtGui(ProxyNamespace):
             return i18n_string(text or "", disambig)
         translate = staticmethod(translate)
 
-    class QIcon(ProxyClass): pass
+    class QIcon(ProxyClass): 
+        def fromTheme(self, themeName):
+            return Literal("%s.QIcon.fromTheme('%s')" % (self.module, themeName))
+
     class QConicalGradient(ProxyClass): pass
     class QLinearGradient(ProxyClass): pass
     class QRadialGradient(ProxyClass): pass

--- a/pysideuic/icon_cache.py
+++ b/pysideuic/icon_cache.py
@@ -48,6 +48,11 @@ class IconCache(object):
 
         iset = _IconSet(iconset, self._base_dir)
 
+        if iset.theme:
+            icon = self._object_factory.createQObject("QIcon", None, (), 
+                                                      is_attribute=False)
+            return icon.fromTheme(iset.theme)
+
         try:
             idx = self._cache.index(iset)
         except ValueError:
@@ -77,10 +82,16 @@ class _IconSet(object):
 
     def __init__(self, iconset, base_dir):
         """Initialise the icon set from an XML tag."""
+        
+        # The icon to get from theme
+        self.theme = iconset.get('theme')
 
         # Set the pre-Qt v4.4 fallback (ie. with no roles).
-        self._fallback = self._file_name(iconset.text, base_dir)
-        self._use_fallback = True
+        if iconset.text:
+            self._fallback = self._file_name(iconset.text, base_dir)
+            self._use_fallback = True
+        else:
+            self._use_fallback = False
 
         # Parse the icon set.
         self._roles = {}


### PR DESCRIPTION
At present setting a theme icon on a menu or toolbar action causes uic to crash. This patch fixes
that issue as well as generating the correct QtQui.QIcon.fromTheme call to use the icon.